### PR TITLE
perf: import and initialize only once, not per function call

### DIFF
--- a/pymongo/compression_support.py
+++ b/pymongo/compression_support.py
@@ -24,7 +24,7 @@ _NO_COMPRESSION = {HelloCompat.CMD, HelloCompat.LEGACY_CMD}
 _NO_COMPRESSION.update(_SENSITIVE_COMMANDS)
 
 try:
-    import snappy  # type:ignore[import-untyped]
+    import snappy  # type:ignore[import-not-found]
 except ImportError:
     pass
 

--- a/pymongo/compression_support.py
+++ b/pymongo/compression_support.py
@@ -23,10 +23,28 @@ _SUPPORTED_COMPRESSORS = {"snappy", "zlib", "zstd"}
 _NO_COMPRESSION = {HelloCompat.CMD, HelloCompat.LEGACY_CMD}
 _NO_COMPRESSION.update(_SENSITIVE_COMMANDS)
 
+try:
+    import snappy  # type:ignore[import-untyped]
+except ImportError:
+    pass
+
+try:
+    import zlib
+except ImportError:
+    pass
+
+try:
+    import zstandard
+except ImportError:
+    pass
+else:
+    zstandard_compressor = zstandard.ZstdCompressor()
+    zstandard_decompressor = zstandard.ZstdDecompressor()
+
 
 def _have_snappy() -> bool:
     try:
-        import snappy  # type:ignore[import-not-found]  # noqa: F401
+        import snappy  # noqa: F401
 
         return True
     except ImportError:
@@ -120,11 +138,8 @@ class CompressionSettings:
 class SnappyContext:
     compressor_id = 1
 
-    @staticmethod
-    def compress(data: bytes) -> bytes:
-        import snappy
-
-        return snappy.compress(data)
+    if _have_snappy():
+        compress = snappy.compress
 
 
 class ZlibContext:
@@ -134,22 +149,16 @@ class ZlibContext:
         self.level = level
 
     def compress(self, data: bytes) -> bytes:
-        import zlib
-
         return zlib.compress(data, self.level)
 
 
 class ZstdContext:
     compressor_id = 3
 
-    @staticmethod
-    def compress(data: bytes) -> bytes:
-        # ZstdCompressor is not thread safe.
-        # TODO: Use a pool?
-
-        import zstandard
-
-        return zstandard.ZstdCompressor().compress(data)
+    # ZstdCompressor is not thread safe.
+    # TODO: Use a pool?
+    if _have_zstd():
+        compress = zstandard_compressor.compress
 
 
 def decompress(data: bytes, compressor_id: int) -> bytes:
@@ -158,18 +167,12 @@ def decompress(data: bytes, compressor_id: int) -> bytes:
         # https://github.com/andrix/python-snappy/issues/65
         # This only matters when data is a memoryview since
         # id(bytes(data)) == id(data) when data is a bytes.
-        import snappy
-
         return snappy.uncompress(bytes(data))
     elif compressor_id == ZlibContext.compressor_id:
-        import zlib
-
         return zlib.decompress(data)
     elif compressor_id == ZstdContext.compressor_id:
         # ZstdDecompressor is not thread safe.
         # TODO: Use a pool?
-        import zstandard
-
-        return zstandard.ZstdDecompressor().decompress(data)
+        return zstandard_decompressor.decompress(data)
     else:
         raise ValueError("Unknown compressorId %d" % (compressor_id,))

--- a/pymongo/message.py
+++ b/pymongo/message.py
@@ -296,7 +296,7 @@ def _compress(
     operation: int, data: bytes, ctx: Union[SnappyContext, ZlibContext, ZstdContext]
 ) -> tuple[int, bytes]:
     """Takes message data, compresses it, and adds an OP_COMPRESSED header."""
-    compressed = ctx.compress(data)
+    compressed = ctx.compress(data)  # type: ignore[call-arg,misc]
     request_id = _randint()
 
     header = _pack_compression_header(


### PR DESCRIPTION
```py
from pymongo import MongoClient

document_count = 60_000
documents = [
    {
        "_id": i,
        "str": "bar",
        "list": ["foo", "bar", "spam", "eggs"],
        "bool": True,
        "nested_dict": {"a": 1, "b": 9999999, "c": 42}
    } for i in range(document_count)
]


def test(compressors):
    client = MongoClient(compressors=compressors) if compressors else MongoClient()

    db = client.test_database
    collection = db.test_collection
    assert not collection.count_documents({})
    
    start = time.perf_counter()
    try:
        # collection.insert_many(documents)
        for doc in documents:
            collection.insert_one(doc)

        assert collection.count_documents({}) == document_count
        for _ in range(200):
            # assert len(collection.find({}).to_list()) == document_count
            assert len(list(collection.find({}))) == document_count
        print(f"{compressors=}, {time.perf_counter() - start}, {document_count=}")
    finally:
        collection.drop()
        client.close()


if __name__ == "__main__":
    test(None)
    test("zlib")
    test("snappy")
    test("zstd")
```